### PR TITLE
grok pattern updated for logs from docker image

### DIFF
--- a/configs/logstash/lancache-pipeline.conf
+++ b/configs/logstash/lancache-pipeline.conf
@@ -12,7 +12,7 @@ filter {
 
             # Extract basic access log fields
             grok {
-                match => { "message" => "\[%{HTTPDATE:timestamp}\] %{IPORHOST:client_ip} %{WORD:http_verb} \"%{URIPATH:url_path}%{URIPARAM:url_querystring}?\" (bytes=%{INT:range_start}-%{INT:range_end}|-) (bytes=%{INT:slice_range_start}-%{INT:slice_range_end}|-) %{NUMBER:http_status_code} (?:%{NUMBER:bytes}|-) (?:%{NUMBER:upstream_bytes_received}|-) (?:%{WORD:cache_status}|-) %{HOSTNAME:upstream_server} (?:%{NUMBER:upstream_http_status_code}|-) (?:%{NUMBER:upstream_response_time}|-) %{QUOTEDSTRING:user_agent}" }
+                match => { "message" => "\[%{HOSTNAME:upstream}\] %{IPORHOST:client_ip} %{URIPATH:url_path} - - - \[%{HTTPDATE:timestamp}\] \"%{WORD:http_verb} %{URIPATH:url_path}(?: HTTP/%{NUMBER:http_version})\" %{NUMBER:http_status_code} (?:%{NUMBER:bytes}|-) %{QUOTEDSTRING:user_agent} %{QUOTEDSTRING:user_agent} \"(?:%{WORD:cache_status}|-)\" \"%{HOSTNAME:upstream_server}\"" }
             }
             mutate { convert => { "bytes" => "integer" } }
             mutate { convert => { "upstream_bytes_received" => "integer" } }


### PR DESCRIPTION
Some days ago was trying to set up lancache-elk dashboard, along with lots of compatibility issues between newer versions of nginx, filebeat, and kibana I found some of "_grokparsefailure", so tried to fix the access.log pattern, it's just a fast review, and it's maybe wrong for some fields and error.log, but it works actually for "General" dashboard.